### PR TITLE
public-merge-devnet3: add extras

### DIFF
--- a/public-merge-devnet3/helmsman/ethereum.yaml
+++ b/public-merge-devnet3/helmsman/ethereum.yaml
@@ -39,6 +39,13 @@ appsTemplates:
     valuesFiles:
       - values/ethereum/lighthouse-beacon.yaml
       - values/ethereum/tolerations/clients.yaml
+  lodestar: &lodestar
+    chart: "ethereum-helm-charts/lodestar"
+    version: "0.1.0"
+    group: lodestar
+    valuesFiles:
+      - values/ethereum/lodestar-beacon.yaml
+      - values/ethereum/tolerations/clients.yaml
 
 apps:
 
@@ -93,6 +100,35 @@ apps:
       replicas: 4
       p2pNodePort.startAt: 31200
       extraEnv[0].value: "nethermind-lighthouse"
+
+  #
+  # Lodestar/Geth
+  #
+  geth-lodestar-0: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30240}}
+  geth-lodestar-1: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30241}}
+  geth-lodestar-2: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30242}}
+  geth-lodestar-3: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30243}}
+  geth-lodestar-4: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30244}}
+  lodestar-geth:
+    <<: *common
+    <<: *lodestar
+    set:
+      replicas: 5
+      p2pNodePort.startAt: 31240
+      extraEnv[0].value: "geth-lodestar"
+
+  #
+  # Lodestar/Nethermind
+  #
+  nethermind-lodestar-0: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30280}}
+  lodestar-nethermind:
+    <<: *common
+    <<: *lodestar
+    set:
+      replicas: 1
+      p2pNodePort.startAt: 31280
+      extraEnv[0].value: "nethermind-lodestar"
+
 
   #
   # Tooling

--- a/public-merge-devnet3/helmsman/ethereum.yaml
+++ b/public-merge-devnet3/helmsman/ethereum.yaml
@@ -121,14 +121,17 @@ apps:
   # Lodestar/Nethermind
   #
   nethermind-lodestar-0: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30280}}
+  nethermind-lodestar-1: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30281}}
+  nethermind-lodestar-2: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30282}}
+  nethermind-lodestar-3: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30283}}
+  nethermind-lodestar-4: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30284}}
   lodestar-nethermind:
     <<: *common
     <<: *lodestar
     set:
-      replicas: 1
+      replicas: 5
       p2pNodePort.startAt: 31280
       extraEnv[0].value: "nethermind-lodestar"
-
 
   #
   # Tooling

--- a/public-merge-devnet3/helmsman/ethereum.yaml
+++ b/public-merge-devnet3/helmsman/ethereum.yaml
@@ -158,11 +158,12 @@ apps:
   # Teku/Nethermind
   #
   nethermind-teku-0: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30340}}
+  nethermind-teku-1: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30341}}
   teku-nethermind:
     <<: *common
     <<: *teku
     set:
-      replicas: 1
+      replicas: 2
       p2pNodePort.startAt: 31340
       extraEnv[0].value: "nethermind-teku"
 

--- a/public-merge-devnet3/helmsman/ethereum.yaml
+++ b/public-merge-devnet3/helmsman/ethereum.yaml
@@ -25,6 +25,13 @@ appsTemplates:
     valuesFiles:
       - values/ethereum/geth.yaml
       - values/ethereum/tolerations/clients.yaml
+  nethermind: &nethermind
+    chart: "ethereum-helm-charts/nethermind"
+    version: "0.2.0"
+    group: nethermind
+    valuesFiles:
+      - values/ethereum/nethermind.yaml
+      - values/ethereum/tolerations/clients.yaml
   lighthouse: &lighthouse
     chart: "ethereum-helm-charts/lighthouse"
     version: "0.1.0"
@@ -71,6 +78,21 @@ apps:
       replicas: 5
       p2pNodePort.startAt: 31140
       extraEnv[0].value: "geth-lighthouse"
+
+  #
+  # Lighthouse/Nethermind
+  #
+  nethermind-lighthouse-0: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30200}}
+  nethermind-lighthouse-1: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30201}}
+  nethermind-lighthouse-2: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30202}}
+  nethermind-lighthouse-3: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30203}}
+  lighthouse-nethermind:
+    <<: *common
+    <<: *lighthouse
+    set:
+      replicas: 4
+      p2pNodePort.startAt: 31200
+      extraEnv[0].value: "nethermind-lighthouse"
 
   #
   # Tooling

--- a/public-merge-devnet3/helmsman/ethereum.yaml
+++ b/public-merge-devnet3/helmsman/ethereum.yaml
@@ -46,6 +46,13 @@ appsTemplates:
     valuesFiles:
       - values/ethereum/lodestar-beacon.yaml
       - values/ethereum/tolerations/clients.yaml
+  teku: &teku
+    chart: "ethereum-helm-charts/teku"
+    version: "0.1.0"
+    group: teku
+    valuesFiles:
+      - values/ethereum/teku-beacon.yaml
+      - values/ethereum/tolerations/clients.yaml
 
 apps:
 
@@ -132,6 +139,32 @@ apps:
       replicas: 5
       p2pNodePort.startAt: 31280
       extraEnv[0].value: "nethermind-lodestar"
+
+
+  #
+  # Teku/Geth
+  #
+  geth-teku-0: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30320}}
+  geth-teku-1: {<<: *common, <<: *geth, set: {p2pNodePort.port: 30321}}
+  teku-geth:
+    <<: *common
+    <<: *teku
+    set:
+      replicas: 2
+      p2pNodePort.startAt: 31320
+      extraEnv[0].value: "geth-teku"
+
+  #
+  # Teku/Nethermind
+  #
+  nethermind-teku-0: {<<: *common, <<: *nethermind, set: {p2pNodePort.port: 30340}}
+  teku-nethermind:
+    <<: *common
+    <<: *teku
+    set:
+      replicas: 1
+      p2pNodePort.startAt: 31340
+      extraEnv[0].value: "nethermind-teku"
 
   #
   # Tooling

--- a/public-merge-devnet3/helmsman/values/ethereum/beaconchain-explorer.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/beaconchain-explorer.yaml
@@ -1,11 +1,12 @@
 image:
-  repository: parithoshj/beacon-explorer
-  tag: merge_payload_fix
+  repository: skylenet/eth2-beaconchain-explorer
+  tag: merge-devnet3-v2
   pullPolicy: IfNotPresent
 
 config:
   # ENV vars will be replaced using the 'init-config' init container
   chain:
+    phase0path: /config-update/phase0.yaml
     slotsPerEpoch: $SLOTS_PER_EPOCH
     secondsPerSlot: $SECONDS_PER_SLOT
     genesisTimestamp: $GENESIS_TIME
@@ -45,6 +46,7 @@ initContainers:
     - -ace
     - >
       apk add jq curl gettext;
+      PHASE0_ENDPOINT=https://config.devnet3.themerge.dev/cl/genesis/config.yaml;
       GENESIS_API_ENDPOINT=http://lighthouse-geth-0.lighthouse-geth-headless.ethereum.svc.cluster.local:5052/eth/v1/beacon/genesis;
       CONFIG_API_ENDPOINT=http://lighthouse-geth-0.lighthouse-geth-headless.ethereum.svc.cluster.local:5052/eth/v1/config/spec;
       GENESIS_DEPLOY_BLOCK_URL=https://config.devnet3.themerge.dev/cl/genesis/deploy_block.txt;
@@ -53,6 +55,7 @@ initContainers:
       while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' $GENESIS_API_ENDPOINT)" != "200" ]]; do sleep 5; done;
       export GENESIS_TIME=$(curl -s $GENESIS_API_ENDPOINT | jq -r '.data.genesis_time');
       curl -s $CONFIG_API_ENDPOINT > config_spec.yaml;
+      curl -s $PHASE0_ENDPOINT > /config-update/phase0.yaml;
       export DEPOSIT_CONTRACT_ADDRESS=$(cat config_spec.yaml | jq '.data.DEPOSIT_CONTRACT_ADDRESS' );
       export MIN_GENESIS_ACTIVE_VALIDATOR_COUNT=$(cat config_spec.yaml | jq -r '.data.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT' );
       export SECONDS_PER_SLOT=$(cat config_spec.yaml | jq -r '.data.SECONDS_PER_SLOT' );

--- a/public-merge-devnet3/helmsman/values/ethereum/lighthouse-beacon.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/lighthouse-beacon.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: sigp/lighthouse
-  tag: latest-unstable
+  repository: skylenet/lighthouse
+  tag: merge-devnet-3
   pullPolicy: IfNotPresent
 
 p2pNodePort:

--- a/public-merge-devnet3/helmsman/values/ethereum/lodestar-beacon.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/lodestar-beacon.yaml
@@ -1,6 +1,6 @@
 image:
   repository: chainsafe/lodestar
-  tag: next@sha256:dc005f6e3301bd648d81b8f847ece120b2a1cc0a7a64d2f3d0a12c4b3c607202
+  tag: next@sha256:e8769d25cd29fa37bfe498e4b378cceb1c5328a84f05cd9c8cf1467ff287352d
   pullPolicy: IfNotPresent
 
 p2pNodePort:

--- a/public-merge-devnet3/helmsman/values/ethereum/lodestar-beacon.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/lodestar-beacon.yaml
@@ -1,0 +1,73 @@
+image:
+  repository: chainsafe/lodestar
+  tag: next@sha256:dc005f6e3301bd648d81b8f847ece120b2a1cc0a7a64d2f3d0a12c4b3c607202
+  pullPolicy: IfNotPresent
+
+p2pNodePort:
+  enabled: true
+
+podManagementPolicy: Parallel
+
+mode: beacon
+
+extraEnv:
+  - name: "SERVICE_PREFIX"
+    value: "" # Will be overwritten via `-set` on main helmsman file
+
+extraArgs:
+  - --genesisStateFile=/data/testnet_spec/genesis.ssz
+  - --paramsFile=/data/testnet_spec/config.yaml
+  - --network.discv5.bootEnrs="$(cat /data/testnet_spec/bootstrap_nodes.txt)"
+  - --network.connectToDiscv5Bootnodes=true
+  - --eth1.depositContractDeployBlock=$(cat /data/testnet_spec/deploy_block.txt)
+  - --eth1.enabled
+  - --eth1.providerUrls="http://${SERVICE_PREFIX}-$(echo $(hostname)| rev | cut -d'-' -f 1 | rev):8545"
+  - --execution.urls="http://${SERVICE_PREFIX}-$(echo $(hostname)| rev | cut -d'-' -f 1 | rev):8545"
+#  - --logLevel=silly
+
+#extraEnv:
+#  - name: DEBUG
+#    value: discv5:service,discv5:sessionService
+
+initContainers:
+- name: init-genesis
+  image: alpine:latest
+  imagePullPolicy: IfNotPresent
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+  command:
+    - sh
+    - -ace
+    - >
+      DEPOSIT_CONTRACT_URI=https://config.devnet3.themerge.dev/cl/genesis/deposit_contract.txt;
+      DEPLOY_BLOCK_URI=https://config.devnet3.themerge.dev/cl/genesis/deploy_block.txt;
+      GENESIS_CONFIG_URI=https://config.devnet3.themerge.dev/cl/genesis/config.yaml;
+      GENESIS_SSZ_URI=https://config.devnet3.themerge.dev/cl/genesis/genesis.ssz;
+      BOOTNODE="enr:-Iq4QKuNB_wHmWon7hv5HntHiSsyE1a6cUTK1aT7xDSU_hNTLW3R4mowUboCsqYoh1kN9v3ZoSu_WuvW9Aw0tQ0Dxv6GAXxQ7Nv5gmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk";
+
+      mkdir -p /data/testnet_spec;
+      if ! [ -f /data/testnet_spec/genesis.ssz ];
+      then
+        wget -O /data/testnet_spec/deposit_contract.txt $DEPOSIT_CONTRACT_URI;
+        wget -O /data/testnet_spec/deploy_block.txt $DEPLOY_BLOCK_URI;
+        wget -O /data/testnet_spec/config.yaml $GENESIS_CONFIG_URI;
+        wget -O /data/testnet_spec/genesis.ssz $GENESIS_SSZ_URI;
+        echo "genesis init done";
+      else
+        echo "genesis exists. skipping...";
+      fi;
+      echo $BOOTNODE > /data/testnet_spec/bootstrap_nodes.txt;
+      echo "bootnode init done: $(cat /data/testnet_spec/bootstrap_nodes.txt)";
+  volumeMounts:
+    - name: storage
+      mountPath: "/data"
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+resources: {}
+
+serviceMonitor:
+  enabled: true

--- a/public-merge-devnet3/helmsman/values/ethereum/nethermind.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/nethermind.yaml
@@ -14,6 +14,7 @@ extraArgs:
 - --Discovery.Bootnodes="$(cat /data/bootnode.txt)"
 - --config=kintsugi_devnet
 - --Init.ChainSpecPath=/data/chainspec.json
+- --Init.IsMining=false
 - --EthStats.Enabled=true
 - --EthStats.Name=$(hostname)
 - --EthStats.Secret=PrivateNetwork
@@ -21,7 +22,7 @@ extraArgs:
 - --JsonRpc.EnabledModules="net,eth,consensus,engine,subscribe,web3"
 - --Mining.Enabled=false
 - --Merge.Enabled=true
-- --Merge.TerminalTotalDifficulty=1000000000
+- --Merge.TerminalTotalDifficulty=5000000000
 - --Init.DiagnosticMode="None"
 #- --log=TRACE
 

--- a/public-merge-devnet3/helmsman/values/ethereum/nethermind.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/nethermind.yaml
@@ -1,0 +1,62 @@
+image:
+  repository: nethermindeth/nethermind
+  tag: kintsugi_v3
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+p2pNodePort:
+  enabled: true
+
+podManagementPolicy: Parallel
+
+extraArgs:
+- --Discovery.Bootnodes="$(cat /data/bootnode.txt)"
+- --config=kintsugi_devnet
+- --Init.ChainSpecPath=/data/chainspec.json
+- --EthStats.Enabled=true
+- --EthStats.Name=$(hostname)
+- --EthStats.Secret=PrivateNetwork
+- --EthStats.Server=ws://ethstats:3000/api/
+- --JsonRpc.EnabledModules="net,eth,consensus,engine,subscribe,web3"
+- --Mining.Enabled=false
+- --Merge.Enabled=true
+- --Merge.TerminalTotalDifficulty=1000000000
+- --Init.DiagnosticMode="None"
+#- --log=TRACE
+
+
+initContainers:
+- name: init-chainspec
+  image: alpine:latest
+  imagePullPolicy: IfNotPresent
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+  command:
+    - sh
+    - -ace
+    - >
+      BOOTNODE=enode://6b457d42e6301acfae11dc785b43346e195ad0974b394922b842adea5aeb4c55b02410607ba21e4a03ba53e7656091e2f990034ce3f8bad4d0cca1c6398bdbb8@137.184.55.117:30303;
+      GENESIS_CHAINSPEC_URI=https://config.devnet3.themerge.dev/el/genesis/chainspec.json;
+      if ! [ -f /data/chainspec.json ];
+      then
+        wget -O /data/chainspec.json $GENESIS_CHAINSPEC_URI;
+        echo "chainspec init done";
+      else
+        echo "chainspec is already there";
+      fi;
+      echo $BOOTNODE > /data/bootnode.txt;
+      echo "bootnode init done: $(cat /data/bootnode.txt)";
+  volumeMounts:
+    - name: storage
+      mountPath: "/data"
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+resources: {}
+
+serviceMonitor:
+  enabled: true

--- a/public-merge-devnet3/helmsman/values/ethereum/nethermind.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/nethermind.yaml
@@ -1,6 +1,6 @@
 image:
   repository: nethermindeth/nethermind
-  tag: kintsugi_v3
+  tag: kintsugi_v3_0.1
   pullPolicy: IfNotPresent
 
 replicas: 1

--- a/public-merge-devnet3/helmsman/values/ethereum/teku-beacon.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/teku-beacon.yaml
@@ -22,9 +22,8 @@ extraArgs:
   - --eth1-deposit-contract-address=$(cat /data/testnet_spec/deposit_contract.txt)
   - --eth1-endpoint="http://${SERVICE_PREFIX}-$(echo $(hostname)| rev | cut -d'-' -f 1 | rev):8545"
   - --Xee-endpoint="http://${SERVICE_PREFIX}-$(echo $(hostname)| rev | cut -d'-' -f 1 | rev):8545"
-  - --metrics-host-allowlist="*" # BUG - THIS needs to be there otherwise the following -Xflags won't work
-  - --Xdata-storage-non-canonical-blocks-enabled=true
-  - --Xnetwork-merge-total-terminal-difficulty=5000000000
+  - --data-storage-non-canonical-blocks-enabled=true
+  - --Xnetwork-merge-total-terminal-difficulty-override=5000000000
   - --logging=INFO
 initContainers:
 - name: init-genesis

--- a/public-merge-devnet3/helmsman/values/ethereum/teku-beacon.yaml
+++ b/public-merge-devnet3/helmsman/values/ethereum/teku-beacon.yaml
@@ -1,0 +1,70 @@
+image:
+  repository: parithoshj/teku
+  tag: merge-b6d8129
+  pullPolicy: IfNotPresent
+
+p2pNodePort:
+  enabled: true
+
+podManagementPolicy: Parallel
+
+mode: "beacon"
+
+extraEnv:
+  - name: "SERVICE_PREFIX"
+    value: "" # Will be overwritten via `-set` on main helmsman file
+
+extraArgs:
+  - --initial-state=/data/testnet_spec/genesis.ssz
+  - --network=/data/testnet_spec/config.yaml
+  - --p2p-discovery-enabled
+  - --p2p-discovery-bootnodes="$(cat /data/testnet_spec/bootstrap_nodes.txt)"
+  - --eth1-deposit-contract-address=$(cat /data/testnet_spec/deposit_contract.txt)
+  - --eth1-endpoint="http://${SERVICE_PREFIX}-$(echo $(hostname)| rev | cut -d'-' -f 1 | rev):8545"
+  - --Xee-endpoint="http://${SERVICE_PREFIX}-$(echo $(hostname)| rev | cut -d'-' -f 1 | rev):8545"
+  - --metrics-host-allowlist="*" # BUG - THIS needs to be there otherwise the following -Xflags won't work
+  - --Xdata-storage-non-canonical-blocks-enabled=true
+  - --Xnetwork-merge-total-terminal-difficulty=5000000000
+  - --logging=INFO
+initContainers:
+- name: init-genesis
+  image: alpine:latest
+  imagePullPolicy: IfNotPresent
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+  command:
+    - sh
+    - -ace
+    - >
+      DEPOSIT_CONTRACT_URI=https://config.devnet3.themerge.dev/cl/genesis/deposit_contract.txt;
+      DEPLOY_BLOCK_URI=https://config.devnet3.themerge.dev/cl/genesis/deploy_block.txt;
+      GENESIS_CONFIG_URI=https://config.devnet3.themerge.dev/cl/genesis/config.yaml;
+      GENESIS_SSZ_URI=https://config.devnet3.themerge.dev/cl/genesis/genesis.ssz;
+      BOOTNODE="enr:-Iq4QKuNB_wHmWon7hv5HntHiSsyE1a6cUTK1aT7xDSU_hNTLW3R4mowUboCsqYoh1kN9v3ZoSu_WuvW9Aw0tQ0Dxv6GAXxQ7Nv5gmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk";
+
+      mkdir -p /data/testnet_spec;
+      if ! [ -f /data/testnet_spec/genesis.ssz ];
+      then
+        wget -O /data/testnet_spec/deposit_contract.txt $DEPOSIT_CONTRACT_URI;
+        wget -O /data/testnet_spec/deploy_block.txt $DEPLOY_BLOCK_URI;
+        wget -O /data/testnet_spec/config.yaml $GENESIS_CONFIG_URI;
+        wget -O /data/testnet_spec/genesis.ssz $GENESIS_SSZ_URI;
+        echo "genesis init done";
+      else
+        echo "genesis exists. skipping...";
+      fi;
+      echo $BOOTNODE > /data/testnet_spec/bootstrap_nodes.txt;
+      echo "bootnode init done: $(cat /data/testnet_spec/bootstrap_nodes.txt)";
+  volumeMounts:
+    - name: storage
+      mountPath: "/data"
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+resources: {}
+
+serviceMonitor:
+  enabled: true


### PR DESCRIPTION
Added new client pairs:
- lighthouse/nethermind
- lodestar/geth
- lodestar/nethermind
- teku/geth
- teku/nethermind

Multiple fixes:
- update lighthouse so that we can get past merge block 
- beaconchain explorer now supporting blocks that contain execution payload transactions
- teku flags