### PR TITLE
Kintsugi: Update client nodes + Firewall nodeport 

### DIFF
--- a/public-merge-kintsugi/helmsman/values/ethereum/beaconchain-explorer.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/beaconchain-explorer.yaml
@@ -74,6 +74,10 @@ initContainers:
         readOnly: true
 
 postgresql:
+  resources:
+    requests:
+      memory: 11Gi
+      cpu: 1200m
   metrics:
     enabled: true
     serviceMonitor:

--- a/public-merge-kintsugi/helmsman/values/ethereum/fauceth.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/fauceth.yaml
@@ -4,7 +4,7 @@ image:
   pullPolicy: IfNotPresent
 
 secretEnv:
-  APP_AMOUNT: "33000000000000000000" # 33 ETH
+  APP_AMOUNT: "11000000000000000000" # 11 ETH
   APP_IMAGEURL: "https://github.com/parithosh/testnet-faucet/raw/master/public/assets/images/ethereum-merge.png"
   APP_TITLE: "Kintsugi FaucETH"
   CHAIN_RPC: "http://dshackle:8545/eth"

--- a/public-merge-kintsugi/helmsman/values/ethereum/lighthouse-beacon.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/lighthouse-beacon.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sigp/lighthouse
-  tag: latest-unstable
+  tag: latest-unstable@sha256:b1d84582f4686bc65a77da84468b21ac0622d027eaef74d682c794893cfd1efa
   pullPolicy: IfNotPresent
 
 p2pNodePort:

--- a/public-merge-kintsugi/helmsman/values/ethereum/lodestar-beacon.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/lodestar-beacon.yaml
@@ -1,6 +1,6 @@
 image:
   repository: chainsafe/lodestar
-  tag: next
+  tag: next@sha256:c906b7f2838b212fce31e5a478839587640b81e69ff6a21438052a9c00d2fb04
   pullPolicy: IfNotPresent
 
 p2pNodePort:

--- a/public-merge-kintsugi/helmsman/values/ethereum/nethermind.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/nethermind.yaml
@@ -1,6 +1,6 @@
 image:
   repository: nethermindeth/nethermind
-  tag: kintsugi_v3_0.1
+  tag: kintsugi_0.6
   pullPolicy: IfNotPresent
 
 replicas: 1
@@ -14,7 +14,7 @@ extraArgs:
 - --Discovery.Bootnodes="$(cat /data/bootnode.txt)"
 - --config=kintsugi_devnet
 - --Init.ChainSpecPath=/data/chainspec.json
-- --Init.IsMining=false
+- --Init.IsMining=true
 - --EthStats.Enabled=true
 - --EthStats.Name=$(hostname)
 - --EthStats.Secret=KintsugiNetwork

--- a/public-merge-kintsugi/helmsman/values/ethereum/prysm-beacon.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/prysm-beacon.yaml
@@ -1,6 +1,6 @@
 image:
   repository: skylenet/prysm-debian
-  tag: kintsugi-30ed0d
+  tag: kintsugi-97027b
   pullPolicy: IfNotPresent
 
 p2pNodePort:

--- a/public-merge-kintsugi/helmsman/values/ethereum/teku-beacon.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/teku-beacon.yaml
@@ -1,6 +1,6 @@
 image:
   repository: consensys/teku
-  tag: develop
+  tag: develop@sha256:85d693dbd7a7edd8e2d2890701805ed5a8b0da0b48482f6e88a11b77cc6372e9
   pullPolicy: IfNotPresent
 
 p2pNodePort:

--- a/public-merge-kintsugi/terraform/main.tf
+++ b/public-merge-kintsugi/terraform/main.tf
@@ -63,6 +63,42 @@ resource "digitalocean_kubernetes_cluster" "main" {
 
 }
 
+# Firewall to open up NodePort range
+resource "digitalocean_firewall" "firewall" {
+  name = local.cluster_name
+
+  tags = [local.cluster_name]
+
+  inbound_rule {
+    protocol         = "udp"
+    port_range       = "30000-32768"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "30000-32768"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
 # Dedicated pool of nodes for ethereum clients
 resource "digitalocean_kubernetes_node_pool" "clients" {
   cluster_id = digitalocean_kubernetes_cluster.main.id


### PR DESCRIPTION
- Updated client nodes to newer images
- Added DO firewall rule to automatically open up the NodePort range. (By default DO creates a firewall for you but only opens ports as they are requested via NodePort. The problem is that the Firewalls have a limit of 50 rules) 
- Bumped beaconchain psql postgres resource requests (Defaults were 256Mi and 200m) 