### PR TITLE
Kintsugi: rate limit faucet /request

### DIFF
--- a/public-merge-kintsugi/helmsman/local-charts/ingress-definitions/templates/ingress.faucet.yaml
+++ b/public-merge-kintsugi/helmsman/local-charts/ingress-definitions/templates/ingress.faucet.yaml
@@ -21,3 +21,34 @@ spec:
             name: fauceth
             port:
               number: 8080
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-faucet-request
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/preserve-trailing-slash: "true"
+    nginx.ingress.kubernetes.io/limit-rpm: "1"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($http_user_agent ~* PCRT00|BBBike|wget) {
+              return 403;
+      }
+spec:
+  tls:
+  - hosts:
+    - "faucet.{{ .Values.domain }}"
+  rules:
+  - host: "faucet.{{ .Values.domain }}"
+    http:
+      paths:
+      - path: /request
+        pathType: Exact
+        backend:
+          service:
+            name: fauceth
+            port:
+              number: 8080

--- a/public-merge-kintsugi/helmsman/values/shared-services/ingress-nginx.yaml
+++ b/public-merge-kintsugi/helmsman/values/shared-services/ingress-nginx.yaml
@@ -3,6 +3,14 @@ controller:
   minAvailable: 1
   extraArgs:
     default-ssl-certificate: "shared-services/default-cert"
+  config:
+    use-forwarded-headers: "true"
+    compute-full-forwarded-for: "true"
+    use-proxy-protocol: "true"
+  service:
+    annotations:
+      service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
+
 
 defaultBackend:
   enabled: true


### PR DESCRIPTION
- Enable proxy protocol so that we have the source IP addresses
- Rate limit by source IP address any http calls to the faucets /request endpoint