### PR TITLE
Kintsugi: RPC rate limit, Faucet+Beaconchain update, fix for proxy protocol internal usage

### DIFF
--- a/public-merge-kintsugi/helmsman/local-charts/ingress-definitions/templates/ingress.rpc.yaml
+++ b/public-merge-kintsugi/helmsman/local-charts/ingress-definitions/templates/ingress.rpc.yaml
@@ -10,6 +10,8 @@ metadata:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/limit-rpm: "500"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       sub_filter_once off;
       sub_filter_types text/html;

--- a/public-merge-kintsugi/helmsman/values/ethereum/beaconchain-explorer.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/beaconchain-explorer.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: skylenet/eth2-beaconchain-explorer
-  tag: merge-devnet3-v2
+  repository: parithoshj/beacon-explorer
+  tag: rebase
   pullPolicy: IfNotPresent
 
 config:
@@ -11,6 +11,7 @@ config:
     secondsPerSlot: $SECONDS_PER_SLOT
     genesisTimestamp: $GENESIS_TIME
     minGenesisActiveValidatorCount: $MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+    altairForkEpoch: $ALTAIR_FORK_EPOCH
   indexer:
     node:
       host: "lighthouse-geth-0.lighthouse-geth-headless.ethereum.svc.cluster.local"
@@ -43,7 +44,7 @@ initContainers:
       runAsUser: 0
     command:
     - bash
-    - -ace
+    - -acex
     - >
       apk add jq curl gettext;
       PHASE0_ENDPOINT=https://config.kintsugi.themerge.dev/cl/genesis/config.yaml;
@@ -60,6 +61,7 @@ initContainers:
       export MIN_GENESIS_ACTIVE_VALIDATOR_COUNT=$(cat config_spec.yaml | jq -r '.data.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT' );
       export SECONDS_PER_SLOT=$(cat config_spec.yaml | jq -r '.data.SECONDS_PER_SLOT' );
       export SLOTS_PER_EPOCH=$(cat config_spec.yaml | jq -r '.data.SLOTS_PER_EPOCH' );
+      export ALTAIR_FORK_EPOCH=$(cat config_spec.yaml | jq -r '.data.ALTAIR_FORK_EPOCH' );
       echo "got genesis time: $GENESIS_TIME";
       envsubst < /config.yaml > /config-update/config.yaml;
       cat /config.yaml;

--- a/public-merge-kintsugi/helmsman/values/ethereum/fauceth.yaml
+++ b/public-merge-kintsugi/helmsman/values/ethereum/fauceth.yaml
@@ -1,10 +1,11 @@
 image:
   repository: skylenet/fauceth
-  tag: "1.2"
+  tag: "bc98a54"
   pullPolicy: IfNotPresent
 
 secretEnv:
-  APP_AMOUNT: "11000000000000000000" # 11 ETH
+  APP_AMOUNT: "10710000000000000000" # 10.71 ETH
   APP_IMAGEURL: "https://github.com/parithosh/testnet-faucet/raw/master/public/assets/images/ethereum-merge.png"
   APP_TITLE: "Kintsugi FaucETH"
-  CHAIN_RPC: "http://dshackle:8545/eth"
+  APP_LOGGING: "VERBOSE"
+  CHAIN_RPC: "http://geth-lighthouse-2:8545"

--- a/public-merge-kintsugi/helmsman/values/shared-services/ingress-nginx.yaml
+++ b/public-merge-kintsugi/helmsman/values/shared-services/ingress-nginx.yaml
@@ -10,6 +10,9 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
+      # Required to deal with Proxy Protocol from internal services/pods
+      # More details in: https://github.com/kubernetes/ingress-nginx/issues/3996
+      service.beta.kubernetes.io/do-loadbalancer-hostname: "themerge.dev"
   metrics:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
- Update faucet and enable verbose logging
- Update beaconchain explorer
- Fix bug with proxy protocol failing when internal pods talked to the public facing DO load balancer
- Add rate limiting to public rpc ingress