### PR TITLE
publice-merge-kiln: add memory limit to beaconchain psql instance 

### DIFF
--- a/public-merge-kiln/helmsman/values/ethereum/beaconchain-explorer.yaml
+++ b/public-merge-kiln/helmsman/values/ethereum/beaconchain-explorer.yaml
@@ -77,6 +77,8 @@ initContainers:
 
 postgresql:
   resources:
+    limits:
+      memory: 25Gi
     requests:
       memory: 11Gi
       cpu: 1200m


### PR DESCRIPTION
To avoid OS OOM killer